### PR TITLE
Update 4_coda_add.sh to use incremental get

### DIFF
--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -32,7 +32,7 @@ DATASETS=(
 )
 
 cd "$CODA_V2_ROOT/data_tools"
-git checkout "e895887b3abceb63bab672a262d5c1dd73dcad92"  # (master which supports incremental get)
+git checkout "c47977d03f96ba3e97c704c967c755f0f8b666cb"  # (master which supports incremental add)
 
 mkdir -p "$DATA_ROOT/Coded Coda Files"
 

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -32,11 +32,20 @@ DATASETS=(
 )
 
 cd "$CODA_V2_ROOT/data_tools"
-git checkout "e895887b3abceb63bab672a262d5c1dd73dcad92"  # (master which supports incremental get)
+git checkout "c47977d03f96ba3e97c704c967c755f0f8b666cb"  # (master which supports incremental add)
 
 for DATASET in ${DATASETS[@]}
 do
-    echo "Pushing messages data to ${DATASET}..."
+    MESSAGES_TO_ADD="$DATA_ROOT/Outputs/Coda Files/$DATASET.json"
+    PREVIOUS_EXPORT="$DATA_ROOT/Coded Coda Files/$DATASET.json"
 
-    pipenv run python add.py "$AUTH" "${DATASET}" messages "$DATA_ROOT/Outputs/Coda Files/$DATASET.json"
+    if [ -e "$MESSAGES_TO_ADD" ]; then  # Stop-gap workaround for supporting multiple pipelines until we have a Coda library
+        if [ -e "$PREVIOUS_EXPORT" ]; then
+            echo "Pushing messages data to ${DATASET} (with incremental get)..."
+            pipenv run python add.py --previous-export-file-path "$PREVIOUS_EXPORT" "$AUTH" "${DATASET}" messages "$MESSAGES_TO_ADD"
+        else
+            echo "Pushing messages data to ${DATASET} (with full download)..."
+            pipenv run python add.py "$AUTH" "${DATASET}" messages "$MESSAGES_TO_ADD"
+        fi
+    fi
 done


### PR DESCRIPTION
This PR updates the coda add script to use the previous Coda file export as the --previous-export-file-path argument to add.py (as a quick reminder, when this argument is provided add.py will only download messages changed since that export was made before figuring out which messages need to be added). This greatly reduces the cost of using Coda by reducing the number of messages that need to be downloaded on each pipeline run, and it slightly improves performance too.

I've been testing this locally for a few days and it's all worked smoothly, so I'm confident enough in this now to deploy it. I've opened the PR against this project rather than G&A because G&A unfortunately doesn't currently have a project with live shows. If approved there's no rush to merge - do it when you think there is a space in the project as we'll initially need to monitor this script closely.